### PR TITLE
Fix Lambda function to correct rate limit invocation function name

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -179,7 +179,7 @@ def check_aws_rate_limit(account_id: str) -> Tuple[bool, str]:
         
         # Invoke rate-limit-aws Lambda
         response = lambda_client.invoke(
-            FunctionName='rate-limit-aws',
+            FunctionName='RateLimitAWS',
             InvocationType='RequestResponse',
             Payload=json.dumps(payload)
         )


### PR DESCRIPTION
- Updated the function name from 'rate-limit-aws' to 'RateLimitAWS' in the `check_aws_rate_limit` function for consistency with AWS naming conventions.
- Ensured proper invocation of the rate limit Lambda function to maintain functionality.